### PR TITLE
Fixed navcurr override issue

### DIFF
--- a/src/views/_screen.scss
+++ b/src/views/_screen.scss
@@ -139,13 +139,15 @@ body {
 			@extend %submenu-colors;
 			font-weight: 400;
 
-			
+			&.wb-navcurr {
+				@extend %base-theme-wb-sm-wb-navcurr;
+			}
 		}
 
 		.slflnk {
 			a {
 				background: #bbb;
-				
+
 				&.wb-navcurr {
 					@extend %base-theme-wb-sm-wb-navcurr;
 				}


### PR DESCRIPTION
.slflnk background color was overriding the .navcurr background color.
