### PR TITLE
Secondary menu: Fix hover issue for contrast ratio on base theme.

### DIFF
--- a/src/views/_screen-md-min.scss
+++ b/src/views/_screen-md-min.scss
@@ -91,7 +91,7 @@
 }
 
 %secmenu-base-theme-menuitem-curr-hover-focus {
-	background: darken(#fff, 50%);
+	background: darken(#fff, 60%);
 	color: lighten(#555, 75%);
 }
 


### PR DESCRIPTION
Contrast ratio fails at 3.0:1, fixed to 60% and achieves 5.7:1.