### PR TITLE
Build: Fix the backwards compatibility copy of assets

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -215,6 +215,9 @@ module.exports = (grunt) ->
 				#Backwards compatibility.
 				#TODO: Remove in v4.1
 				options:
+					noProcess: [
+						'**/*.{png,gif,jpg,ico,ttf,otf,woff,svg,swf}'
+					]
 					process: (content, filepath) ->
 						if filepath.match(/\.css/)
 							return content.replace(/\.\.\/\.\.\/wet-boew\/(assets|fonts)/g, '../$1')


### PR DESCRIPTION
The grunt copy task was corrupting assets