### PR TITLE
Theme: Reworked main background colour variable into a content area one.

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -11,9 +11,8 @@ $body-bg: #eee; // Body element's background colour (Bootstrap override).
 //Breadcrumb
 $breadcrumb-bg: #fff; // Inner background colour (Bootstrap override).
 
-// Main
-$main-bg: #fff; // Main element's background colour (WET override).
-
+// Content area
+$content-bg: $breadcrumb-bg; // Content area's background colour (WET override).
 $banner-gradient-start: #4065b3;
 $banner-gradient-end: #33479e;
 $base-theme-mb-pnl-bg: #ccc;

--- a/src/views/_screen-sm-min.scss
+++ b/src/views/_screen-sm-min.scss
@@ -7,18 +7,6 @@
 /*
   @title: Small view and over (screen only)
  */
-body {
-	> {
-		header {
-			+ {
-				.container {
-					background-color: $main-bg;
-				}
-			}
-		}
-	}
-}
-
 footer {
 	background: #cf3f0e;
 	border-top: 1px solid #bbb;


### PR DESCRIPTION
* Renames the $main-bg variable to $content-bg.
* Adjusts the $content-bg variable's declaration to re-use $breadcrumb-bg's value.
* Removes redundant code that used to set the content container's background colour. It's now built-into wet-boew via wet-boew/wet-boew#7920.
* Depends on wet-boew/wet-boew#7920.