### PR TITLE
Theme index: Corrected French i18n string references.

### DIFF
--- a/site/pages/index-fr.hbs
+++ b/site/pages/index-fr.hbs
@@ -5,21 +5,21 @@
 	"parentdir": "theme-base",
 	"language": "fr",
 	"altLangPrefix": "index",
-	"dateModified": "2014-08-15"
+	"dateModified": "2017-05-12"
 }
 ---
 <section>
 	<h2>Table des matières</h2>
 	<ul>
 {{#withSort languages}}
-		<li><a href="#{{this}}">{{#with ..}}{{i18n "lang-en" language=../this}}{{/with}}</a></li>
+		<li><a href="#{{this}}">{{#with ..}}{{i18n "lang-fr" language=../this}}{{/with}}</a></li>
 {{/withSort}}
 	</ul>
 </section>
 
 {{#withSort languages}}
 <section>
-	<h2 id="{{this}}">{{#with ..}}{{i18n "lang-en" language=../this}}{{/with}}</h2>
+	<h2 id="{{this}}">{{#with ..}}{{i18n "lang-fr" language=../this}}{{/with}}</h2>
 	<ul>
 		<li><a href="content-{{this}}.html">Page de contenu</a></li>
 		<li><a href="content-secmenu-{{this}}.html">Page de contenu - Menu secondaire</a></li>


### PR DESCRIPTION
This theme's French index page was previously referencing English i18n strings in its table of contents and headings, resulting in "Frenglish" page content.

This commit adjusts all affected i18n string references to their French counterparts.