### PR TITLE
Search: Fixed layout issues with minified HTML/RTL.

### DIFF
--- a/src/views/_screen-sm-max.scss
+++ b/src/views/_screen-sm-max.scss
@@ -154,21 +154,10 @@
 	}
 }
 
-#wb-srch-sub {
-	float: right;
-	margin-left: 5px;
-}
-
 [dir=rtl] {
 	#wb-srch {
 		margin-left: 15px;
 		text-align: left;
-	}
-
-	#wb-srch-sub {
-		float: right;
-		margin-left: 5px;
-		margin-right: 0;
 	}
 
 	#mb-pnl {

--- a/src/views/_screen.scss
+++ b/src/views/_screen.scss
@@ -62,6 +62,11 @@ body {
 	}
 }
 
+#wb-srch-sub {
+	float: right;
+	margin-left: 5px;
+}
+
 %base-theme-wb-sm-wb-navcurr {
 	background: #333;
 	color: #fff;
@@ -162,6 +167,14 @@ body {
 }
 
 [dir=rtl] {
+	#wb-srch-sub {
+		float: left;
+		margin: {
+			left: 0;
+			right: 5px;
+		}
+	}
+
 	#wb-dtmd {
 		float: left;
 	}


### PR DESCRIPTION
In medium/large views, the search field/button's layout used to rely on space/line break/tab characters being present in-between their elements in HTML markup. Their presence produced a space in-between the search field/button. But in pages that use minified HTML, the space disappeared, which made the field and button "stick" together.

It turns out that this theme's small view and under SCSS file contained selectors that produced a predictable amount of space for the search feature in noscript/wbdisable mode. But its default selector's properties were redeclared in the right to left (RTL) selector instead of being inverted.

This commit moves the aforementioned selectors into this theme's screen SCSS file and corrects the RTL selector's properties. Combined, these resolve layout issues in medium/large views and fix RTL layouts in smaller views.

Related to wet-boew/wet-boew#8061.