### PR TITLE
Build: Modified sass-lint settings to require EOF newlines.

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -3,6 +3,7 @@ options:
   merge-default-rules: false
 rules:
   class-name-format: 0
+  final-newline: 2
   function-name-format: 0
   id-name-format: 0
   indentation:


### PR DESCRIPTION
Sass-lint doesn't require SCSS files to end with a newline by default. However, this theme's .editorconfig file does.

This commit makes this theme's sass-lint settings consistent with its .editorconfig file in that respect.

Port of wet-boew/wet-boew#8200 and wet-boew/wet-boew#8201.

@nschonni @LaurentGoderre FYI.