### PR TITLE
Theme: Reference SVG logos with img element instead of object.

### DIFF
--- a/site/layouts/splashpage.hbs
+++ b/site/layouts/splashpage.hbs
@@ -20,7 +20,7 @@
 			<div class="container">
 				<div class="row mrgn-tp-lg mrgn-bttm-lg">
 					<div class="col-md-8 col-md-offset-2">
-						<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/logo.svg" aria-label="{{{i18n "site-title"}}}"></object>
+						<img src="{{assets}}/../{{site.theme}}/assets/logo.svg" alt="{{{i18n "site-title"}}}" />
 					</div>
 				</div>
 			</div>

--- a/src/assets/logo.svg
+++ b/src/assets/logo.svg
@@ -4,8 +4,7 @@
 wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html  -->
 <defs>
     <style type="text/css">
-        .wxt_logo {fill:#000;}
-        @media screen {.wxt_logo {fill: #FFF; stroke: #000; stroke-width:2}}
+        .wxt_logo {fill: #FFF; stroke: #000; stroke-width: 2}
     </style>
 </defs>
 <g transform="matrix(1,0,0,0.99999897,-9.6901386,-462.70603)">

--- a/src/views/_screen-sm-max.scss
+++ b/src/views/_screen-sm-max.scss
@@ -139,8 +139,10 @@
 		z-index: 1;
 	}
 
-	object,
-	img {
+	// Possibly needed for backwards compatibility with theme-base 4.0.27 and below's HTML markup.
+	// Remove object references from all of this theme's logo selectors in theme-base 4.1+.
+	img,
+	object {
 		height: 1.21em;
 		margin: 0;
 		position: absolute;


### PR DESCRIPTION
* Port of wet-boew/wet-boew#8282.
* Related to wet-boew/wet-boew#8276.
* Removes the logo SVG's inline media query and promotes its former CSS styles to be the default ones.
  * This theme's variant of the WET logo uses a black outline, so it's presentable as-is in any scenario.